### PR TITLE
Fixed invalid conversion from ‘char’ to ‘const char*’ in mgen.cpp

### DIFF
--- a/src/common/mgen.cpp
+++ b/src/common/mgen.cpp
@@ -432,7 +432,7 @@ MgenTransport* Mgen::FindTransportByInterface(const char*           interfaceNam
                     {
                         if (0 == next->GroupCount())
                         {
-                            next->SetMulticastInterface('\0');
+                            next->SetMulticastInterface(NULL);
                             return nextTransport;
                         }
                         else


### PR DESCRIPTION
Hi,

I suggesting this backfix to the tag v5.02c to fix the following compilation issue:

```
../src/common/mgen.cpp: In member function ‘MgenTransport* Mgen::FindTransportByInterface(const char*, UINT16, ProtoAddress::Type)’:
../src/common/mgen.cpp:435:57: error: invalid conversion from ‘char’ to ‘const char*’ [-fpermissive]
  435 |                             next->SetMulticastInterface('\0');
      |                                                         ^~~~
      |                                                         |
      |                                                         char
In file included from ../include/mgenFlow.h:5,
                 from ../include/mgen.h:5,
                 from ../src/common/mgen.cpp:3:
../include/mgenTransport.h:280:44: note:   initializing argument 1 of ‘virtual bool MgenUdpTransport::SetMulticastInterface(const char*)’
  280 |     bool SetMulticastInterface(const char* interfaceName);
      |                                ~~~~~~~~~~~~^~~~~~~~~~~~~
make: *** [Makefile.common:30: ../src/common/mgen.o] Error 1
```

Cheers,
Jordan