### PR TITLE
Add protolib as a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# protolib
-protolib/
-
 # build executables
 makefiles/mgen
 makefiles/mpmgr

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "protolib"]
+	path = protolib
+	url = https://github.com/USNavalResearchLaboratory/protolib

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requires Protolib:
     
     git clone https://github.com/USNavalResearchLaboratory/mgen.git
     cd mgen
-    git clone https://github.com/USNavalResearchLaboratory/protolib.git
+    git submodule update --init
     cd makefiles
     make -f Makefile.linux
 


### PR DESCRIPTION
This commit adds protolib as a git submodule as suggested in issue #13.