### PR TITLE
Fix crash bug on pcap2mgen startup

### DIFF
--- a/src/common/pcap2mgen.cpp
+++ b/src/common/pcap2mgen.cpp
@@ -47,7 +47,8 @@ const char* const CMD_LIST[] =
     "-trace",     // Prepends MGEN log lines with epoch time and MAC src/addr info
     "+rxlog",     // Turns on/off recv log info. For report messages only
     "-flush",     // flush writes to outfile
-    "+window"     // Sets analytic window
+    "+window",     // Sets analytic window
+    NULL
 };
 
 


### PR DESCRIPTION
The `CMD_LIST` of `pcap2mgen` was missing an end marker.  Given the code I assumed this was supposed to be a `NULL`.  This has been added which fixes the crashing behavior.