### PR TITLE
Add mgen epochtimestamp command line argument

### DIFF
--- a/doc/mgen.xml
+++ b/doc/mgen.xml
@@ -803,10 +803,10 @@
             transport a common retry pattern should be used by all the flows
             or the last attribute set "wins".</entry>
           </row>
-	  <row>
+          <row>
             <entry><literal>epochtimestamp</literal></entry>
 
-            <entry>Log timestamps as epoch time in second.microsecond.<
+            <entry>Log timestamps as epoch time in second.microsecond.
             format.</entry>
           </row>
         </tbody>

--- a/doc/mgen.xml
+++ b/doc/mgen.xml
@@ -133,6 +133,7 @@
      [df {on|off}][analytics] [window &lt;secs&gt;]]
      [report] [suspend &lt;flowId(s)&gt;] [resume &lt;flowId(s)&gt;] [reset &lt;flowId(s)&gt;]
      [retry &lt;count&gt;[/&lt;delay&gt;]
+     [epochtimestamp]
 
 </programlisting>
 
@@ -801,6 +802,12 @@
             if the retry count is set to -1. If multiple flows are sharing the
             transport a common retry pattern should be used by all the flows
             or the last attribute set "wins".</entry>
+          </row>
+	  <row>
+            <entry><literal>epochtimestamp</literal></entry>
+
+            <entry>Log timestamps as epoch time in second.microsecond.<
+            format.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/include/mgen.h
+++ b/include/mgen.h
@@ -169,6 +169,7 @@ class Mgen
       RETRY,     // Enables TCP retry connection attempts
       PAUSE,     // Pauses flow while tcp attempts to reconnect
       RECONNECT, // Enables TCP reconnect
+      EPOCH_TIMESTAMP, // Log timetamp as epoch time in sec.usec format
       RESET
     };
 
@@ -209,7 +210,10 @@ class Mgen
     // Alternative logging function for WinCE debug window when logging to stdout/stderr
     static int Mgen::LogToDebug(FILE* filePtr, const char* format, ...);
 #endif  // if/else _WIN32_WCE
-    static void LogTimestamp(FILE* filePtr, const struct timeval& theTime, bool localTime);
+    static void (*LogTimestamp)(FILE*, const struct timeval&, bool);
+    static void SetEpochTimestamp(bool enable);
+    static void LogEpochTimestamp(FILE* filePtr, const struct timeval& theTime, bool localTime);
+    static void LogLegacyTimestamp(FILE* filePtr, const struct timeval& theTime, bool localTime);
     bool ParseScript(const char* path);
 #if OPNET  // JPH 11/16/2005
     bool ParseScript(List*);

--- a/src/common/mgenApp.cpp
+++ b/src/common/mgenApp.cpp
@@ -56,7 +56,8 @@ void MgenApp::Usage()
             "     [queue <queueSize>][broadcast {on|off}]\n"
             "     [convert <binaryLog>][debug <debugLevel>]\n"
             "     [gpskey <gpsSharedMemoryLocation>]\n"
-            "     [boost] [reuse {on|off}]\n");
+            "     [boost] [reuse {on|off}]\n"
+            "     [epochtimestamp]\n");
 }  // end MgenApp::Usage()
 
 
@@ -81,6 +82,7 @@ const char* const MgenApp::CMD_LIST[] =
     "+gpskey",    // Override default gps shared memory location
     "+logdata",    // log optional data attribute? default ON
     "+loggpsdata", // log gps data? default ON
+    "-epochtimestamp", // epoch timesetamps? default OFF
 //   "-analytics",  // enables MGEN analytics reporting on received flows
     NULL
 };
@@ -465,6 +467,10 @@ bool MgenApp::OnCommand(const char* cmd, const char* val)
     {
         if (!dispatcher.BoostPriority())
             fprintf(stderr, "Unable to boost process priority.\n");
+    }
+    else if (!strncmp("epochtimestamp", lowerCmd, len))
+    {
+        mgen.SetEpochTimestamp(true);
     }
     else if (!strncmp("help", lowerCmd, len))
     {


### PR DESCRIPTION
Resubmitting pull request #10 reworked as a command line argument.

Add mgen epochtimestamp command line argument to change logged timestamps to epoch time in sec.usec format. Default timestamp remains legacy HH:MM:SS.usec.